### PR TITLE
Update: use inherited generateApiMetadata() instead of AbstractApiUtils (fixes #36)

### DIFF
--- a/lib/MongoDBLoggerModule.js
+++ b/lib/MongoDBLoggerModule.js
@@ -1,4 +1,4 @@
-import { AbstractApiModule, AbstractApiUtils } from 'adapt-authoring-api'
+import { AbstractApiModule } from 'adapt-authoring-api'
 import apidefs from './apidefs.js'
 /**
  * Module for logging message to the MongoDB
@@ -33,7 +33,7 @@ class MongoDBLoggerModule extends AbstractApiModule {
         meta: apidefs.queryLogs
       }
     ]
-    AbstractApiUtils.generateApiMetadata(this)
+    this.generateApiMetadata()
   }
 
   /** @override */

--- a/tests/MongoDBLoggerModule.spec.js
+++ b/tests/MongoDBLoggerModule.spec.js
@@ -12,14 +12,12 @@ import assert from 'node:assert/strict'
 const AbstractApiModule = class {
   queryHandler () { return function queryHandler () {} }
   requestHandler () { return function requestHandler () {} }
-}
-const AbstractApiUtils = {
   generateApiMetadata () {}
 }
 
 // Register the stubs before importing the module under test
 mock.module('adapt-authoring-api', {
-  namedExports: { AbstractApiModule, AbstractApiUtils }
+  namedExports: { AbstractApiModule }
 })
 mock.module('../lib/apidefs.js', {
   defaultExport: { getLogs: {}, getLog: {}, queryLogs: {} }
@@ -99,13 +97,11 @@ describe('MongoDBLoggerModule', () => {
       assert.deepEqual(route.permissions, { post: ['read:logs'] })
     })
 
-    it('should call AbstractApiUtils.generateApiMetadata', async () => {
+    it('should call this.generateApiMetadata()', async () => {
       let called = false
-      const origGenerate = AbstractApiUtils.generateApiMetadata
-      AbstractApiUtils.generateApiMetadata = () => { called = true }
+      instance.generateApiMetadata = () => { called = true }
       await instance.setValues()
       assert.ok(called, 'generateApiMetadata should have been called')
-      AbstractApiUtils.generateApiMetadata = origGenerate
     })
   })
 


### PR DESCRIPTION
## Summary
- Replaces `AbstractApiUtils.generateApiMetadata(this)` with `this.generateApiMetadata()`
- Removes `AbstractApiUtils` import (being deleted from adapt-authoring-api)
- Updates test mock to provide `generateApiMetadata` on the stub class instead of a separate utils object

## Merge order
Merge **after** adapt-authoring-api PR #72 (which adds the instance method and removes AbstractApiUtils)

## Test plan
- [x] 25 mongodblogger tests pass
- [x] Linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)