### PR TITLE
Update: Remove absorbed module dependencies

### DIFF
--- a/lib/MongoDBLoggerModule.js
+++ b/lib/MongoDBLoggerModule.js
@@ -21,7 +21,7 @@ class MongoDBLoggerModule extends AbstractApiModule {
      */
     this.logInternalErrors = this.getConfig('logInternalErrors')
     // try and create the capped collection
-    const [db, logger] = await this.app.waitForModule('mongodb', 'logger')
+    const db = await this.app.waitForModule('mongodb')
     try {
       const max = this.getConfig('maxLogCount')
       if (max > 0) {
@@ -35,7 +35,7 @@ class MongoDBLoggerModule extends AbstractApiModule {
         return this.log('warn', `'${this.collectionName}' collection already exists and is not capped`)
       }
     }
-    logger.logHook.tap(this.logToDb.bind(this))
+    this.app.logger.logHook.tap(this.logToDb.bind(this))
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "adapt-authoring-api": "^3.0.0"
   },
   "peerDependencies": {
-    "adapt-authoring-core": "^2.0.0",
-    "adapt-authoring-logger": "^1.1.2",
+    "adapt-authoring-core": "^3.0.0",
     "adapt-authoring-mongodb": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Update

- Remove `adapt-authoring-logger` peerDependency (now a bootstrap library in core)
- Access logHook via `app.logger` instead of `waitForModule('logger')`
- Bump `adapt-authoring-core` peer to `^3.0.0`