### PR TITLE
New: Searchable log text/module and a distinct-modules endpoint

### DIFF
--- a/lib/MongoDBLoggerModule.js
+++ b/lib/MongoDBLoggerModule.js
@@ -39,6 +39,23 @@ class MongoDBLoggerModule extends AbstractApiModule {
   }
 
   /**
+   * Request handler returning the distinct module names present in the logs,
+   * sorted, for populating the logs module filter.
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {Function} next
+   */
+  async queryModules (req, res, next) {
+    try {
+      const db = await this.app.waitForModule('mongodb')
+      const modules = await db.getCollection(this.collectionName).distinct('module')
+      res.json(modules.filter(Boolean).sort())
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
    * Logs a message to the database
    * @param {Date} date When the data was logged
    * @param {String} level Severity of the message

--- a/routes.json
+++ b/routes.json
@@ -56,6 +56,27 @@
       }
     },
     {
+      "route": "/modules",
+      "handlers": { "get": "queryModules" },
+      "permissions": { "get": ["read:${scope}"] },
+      "meta": {
+        "get": {
+          "summary": "List logged modules",
+          "description": "Returns the distinct module names present in the logs, for filtering.",
+          "responses": {
+            "200": {
+              "description": "Distinct module names",
+              "content": {
+                "application/json": {
+                  "schema": { "type": "array", "items": { "type": "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "route": "/:_id",
       "handlers": { "get": "requestHandler" },
       "permissions": { "get": ["read:${scope}"] },

--- a/schema/log.schema.json
+++ b/schema/log.schema.json
@@ -19,7 +19,8 @@
     },
     "module": {
       "description": "Module responsible for creating the log",
-      "type": "string"
+      "type": "string",
+      "isSearchable": true
     },
     "timestamp": {
       "description": "Time log was created",
@@ -29,7 +30,8 @@
     },
     "data": {
       "description": "The data to be logged",
-      "type": "array"
+      "type": "array",
+      "isSearchable": true
     }
   },
   "required": ["level"]


### PR DESCRIPTION
### New
* Add `GET /api/logs/modules`, returning the distinct module names present in the logs (sorted) — for populating a module filter in the UI.

### Update
* Mark the `data` (log text) and `module` fields `isSearchable`, so the shared `?search=` query matches log content rather than nothing.

### Testing
1. `GET /api/logs/modules` returns a sorted list of module names.
2. A log query with `?search=<text>` matches entries whose message/module contain the text.